### PR TITLE
カラムgrammar追加実装

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -5,3 +5,5 @@
     // background-color: #1e365a;
     color: #000000;
   }
+
+  

--- a/app/controllers/english_words_controller.rb
+++ b/app/controllers/english_words_controller.rb
@@ -36,7 +36,7 @@ class EnglishWordsController < ApplicationController
 
   private
   def key_word_params
-    params.require(:english_word).permit(:key_word,:key_word_kana)
+    params.require(:english_word).permit(:key_word,:key_word_kana,:grammar)
   end
 
 end

--- a/app/views/english_words/edit.html.erb
+++ b/app/views/english_words/edit.html.erb
@@ -26,6 +26,7 @@
       <%# 日本語訳フォーム %>
       <div class="new--contents__main__word">
         ◉ 英単語の意味(日本語) :
+      <%= form.text_field :key_word_kana, placeholder: :日本語訳, class: :form__btn__japanese %>
       </div>
       <%# 文法プルダウン選択フォーム %>
       <div class="new--contents__main__word">

--- a/app/views/english_words/index.html.erb
+++ b/app/views/english_words/index.html.erb
@@ -13,7 +13,7 @@
         <div class="content__left__flame">
           <% @english_words.each do |english_word|%>
         <div class="content__left__flame__box">
-            <%= link_to ("#{english_word.key_word}: 文法"), english_word_path(english_word.id), class: "content__left__box--word"  %> <%#式展開を記述("#{}")%>
+            <%= link_to ("#{english_word.key_word} : #{english_word.grammar}"), english_word_path(english_word.id), class: "content__left__box--word"  %> <%#式展開を記述("#{}")%>
         </div>
           <%end%>
         </div>  

--- a/app/views/english_words/new.html.erb
+++ b/app/views/english_words/new.html.erb
@@ -25,13 +25,13 @@
       </div>
       <%# 日本語訳フォーム %>
       <div class="new--contents__main__word">
-        ◉ 英単語の意味(日本語) :
+        ◉ 日本語訳 :
       <%= form.text_field :key_word_kana, placeholder: :日本語訳, class: :form__btn__japanese %>
       </div>
       <%# 文法プルダウン選択 %>
       <div class="new--contents__main__word">
         ◉ 文法の種類 :
-      <%= form.select :grammar, [["名詞", "名詞"], ["形容詞", ""], ["動詞", ""], ["副詞", ""], ["前置詞", ""], ["接続詞", ""], ["熟語", ""]],include_blank: "文法を選択して下さい" %>
+      <%= form.select :grammar, [["名詞", "名詞"], ["形容詞", "形容詞"], ["動詞", "動詞"], ["副詞", "副詞"], ["前置詞", "前置詞"], ["接続詞", "接続詞"], ["熟語", "熟語"]],include_blank: "文法を選択して下さい" %>
       </div>
       <%# 登録ボタン %>
       <%= form.submit '登録する', class: :form__submit__btn %>

--- a/app/views/english_words/show.html.erb
+++ b/app/views/english_words/show.html.erb
@@ -31,6 +31,7 @@
       </div>
       <div class="new--contents__main--grammar">
         文法
+       <%= @english_words.grammar %>
       </div>
       <div class="new--contents__main--submit">
       </div>

--- a/db/migrate/20200302134943_add_grammar_to_english_words.rb
+++ b/db/migrate/20200302134943_add_grammar_to_english_words.rb
@@ -1,0 +1,5 @@
+class AddGrammarToEnglishWords < ActiveRecord::Migration[5.2]
+  def change
+    add_column :english_words, :grammar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_155757) do
+ActiveRecord::Schema.define(version: 2020_03_02_134943) do
 
   create_table "english_words", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "key_word"
     t.text "key_word_kana"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "grammar"
   end
 
 end


### PR DESCRIPTION
# what
　・english_wordsテーブルにgrammarカラムを追加

# why
　・プルダウン選択でgrammar(文法)を選択できるようにしていたが、DBにカラムがなくデータ保存がされなかった為