### PR TITLE
マイページの破棄

### DIFF
--- a/app/views/english_words/index.html.erb
+++ b/app/views/english_words/index.html.erb
@@ -16,12 +16,13 @@
   <div class="contents__main">
       <%# カレンダー&youtube %>
       <div class="content__left"> 
-           <b><div class="content__left__title">【単語一覧】</div></b>
+        <% if user_signed_in?%>
+           <b><div class="content__left__title"><%= %"【#{current_user.nickname}さんの登録単語一覧】"%></div></b>
+        <% end %>
         <div class="content__left__flame">
         <% if user_signed_in?%>
           <% @english_words.each do |english_word|%>
         <div class="content__left__flame__box">
-            <%= link_to english_word.user.nickname,class:"content__left__box--word" %>
             <%= link_to ("#{english_word.key_word} : #{english_word.grammar}"), english_word_path(english_word.id), class: "content__left__box--word"  %> <%#式展開を記述("#{}")%>
         </div>
           <% end %>


### PR DESCRIPTION
# what　
　・マイページの実装を一度白紙に戻す

# why
　・indexページでマイページの役割をはたそうとした所、エラーが出て実装イメージが浮かばなかった為、マイページを別ページで挟む事を検討。
しかしながらエラーが回避できたため、一度は当初の予定に戻す事となった為

[![Image from Gyazo](https://i.gyazo.com/9dd17f9337e2991e56e7cfd398e442d8.gif)](https://gyazo.com/9dd17f9337e2991e56e7cfd398e442d8)

 