### PR TITLE
indexページの仕様変更

### DIFF
--- a/app/controllers/english_words_controller.rb
+++ b/app/controllers/english_words_controller.rb
@@ -1,8 +1,6 @@
 class EnglishWordsController < ApplicationController
   def index
-    @english_words = EnglishWord.all 
-    # @english_word = EnglishWord.find(params[:id])
-
+    @english_words = EnglishWord.all
   end
 
   def new

--- a/app/views/english_words/index.html.erb
+++ b/app/views/english_words/index.html.erb
@@ -4,6 +4,7 @@
     <div class="contents__top--menu">
       <% if user_signed_in?%>
         <b><%= link_to '英単語の登録', new_english_word_path, class: "content2--bottom--btn" %></b> 
+        <b><%= link_to "#{current_user.nickname}さんのページ", new_english_word_path, class: "content2--bottom--btn"%></b>
         <b><%= link_to '3択クイズ', quiz_english_words_path, class: "content2-bottom--btn" %></b>
         <b><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "content2-bottom--btn"%></b> 
       <% else %>
@@ -16,17 +17,13 @@
   <div class="contents__main">
       <%# カレンダー&youtube %>
       <div class="content__left"> 
-        <% if user_signed_in?%>
-           <b><div class="content__left__title"><%= %"【#{current_user.nickname}さんの登録単語一覧】"%></div></b>
-        <% end %>
+        <b><div class="content__left__title">【みんなの登録単語一覧】</div></b>
         <div class="content__left__flame">
-        <% if user_signed_in?%>
           <% @english_words.each do |english_word|%>
         <div class="content__left__flame__box">
             <%= link_to ("#{english_word.key_word} : #{english_word.grammar}"), english_word_path(english_word.id), class: "content__left__box--word"  %> <%#式展開を記述("#{}")%>
         </div>
           <% end %>
-        <% end %>
         </div>  
       </div>
       <%# メニューボタン %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'english_words#index'
-  resources :english_words,except: :index do
+
+  resources :english_words do
     collection do
         get :quiz #quizアクションを追加
     end


### PR DESCRIPTION
# what 
　・indexページのif signed_in?による単語一覧表示を削除

# why 
　・indexページでマイページ実装を行う事はidが付与されないルーティングの関係上むずかしい為、
　　マイページを実装予定。
