### PR TITLE
マイページの編集

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,21 +1,21 @@
-<div class="postTitle">
-  <%= @user.nickname %>さんの投稿一覧
-</div>
-
-<div class="postTitle">
-<% @english_word.each do |e| %>
-  <div class="content">
-    <div class="content__left">
-      <div class="content__left--image"></div>
-    </div>
-    <div class="content__right">
-      <div class="content__right__top">
-      </div>
-      <div class="content__right__bottom">
-        <div class="content__right__bottom--userName">
+<div class="contents row">
+  <b><p><%= current_user.nickname %>さんのマイページ</p></b>
+  <b><p><%=link_to 'Topページに戻る', root_path, class: "contents2--bottom--btn " %></p></b>
+  <b><p><%=link_to '単語を登録する', new_english_word_path, class: "contents2--bottom--btn " %></p></b>
+  <div class="contents__main">
+      <div class="content__left"> 
+        <b><div class="content__left__title"><%="【#{current_user.nickname}さんの登録単語一覧】"%></div></b>
+        <div class="content__left__flame">
+          <% @english_word.each do |english_words|%>
+        <div class="content__left__flame__box">
+          <%= simple_format(english_words.key_word) %>
+          <%= simple_format(english_words.key_word_kana) %>
+          <span class="name"><%= english_words.grammar %></span>
+            <%= link_to ("#{english_words.key_word} : #{english_words.grammar}"), english_word_path(english_words.id), class: "content__left__box--word"%>
         </div>
-        <div class="content__right__bottom--date">
-          <%= e.created_at %>
- <% end %>         
+          <% end %>
+        </div>  
+      </div>
+  </div>
 </div>
 


### PR DESCRIPTION
# what
　・current_userのみの単語登録一覧が表示されるようにマイページのviewsを実装
　・マイページから単語新規登録ページに遷移できるようにlinkを設置

# why
　・ユーザスケーラビリティを考慮してcurrent_userの情報のみを表示する必要がある為
[![Image from Gyazo](https://i.gyazo.com/be6b5839c8514f9949d18f241fdcdbc1.gif)](https://gyazo.com/be6b5839c8514f9949d18f241fdcdbc1)